### PR TITLE
using 2.2.2-dev

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -38,9 +38,9 @@ RUN chmod -R a+rw /kb/module
 # https://groups.google.com/forum/#!topic/qualimap/boCICeLA_OM
 RUN cd /kb/module && \
     wget https://bitbucket.org/kokonech/qualimap/downloads/qualimap-build-26-08-18.tar.gz && \
-    tar -xzf qualimap-build-10-10-16.tar.gz && \
-    rm -rf qualimap-build-10-10-16.tar.gz && \
-    mv qualimap-build-10-10-16 qualimap-bin
+    tar -xzf qualimap-build-26-08-18.tar.gz && \
+    rm -rf qualimap-build-26-08-18.tar.gz && \
+    mv qualimap-build-26-08-18 qualimap-bin
 
 # copy in sdk module files
 COPY ./ /kb/module

--- a/Dockerfile
+++ b/Dockerfile
@@ -28,11 +28,19 @@ RUN mkdir -p /kb/module/work
 RUN chmod -R a+rw /kb/module
 
 # install qualimap
+# RUN cd /kb/module && \
+#    wget https://bitbucket.org/kokonech/qualimap/downloads/qualimap_v2.2.1.zip && \
+#    unzip qualimap_v2.2.1.zip && \
+#    rm -rf qualimap_v2.2.1.zip && \
+#    mv qualimap_v2.2.1 qualimap-bin
+
+# using 2.2.2-dev due to incorrect total reads count
+# https://groups.google.com/forum/#!topic/qualimap/boCICeLA_OM
 RUN cd /kb/module && \
-    wget https://bitbucket.org/kokonech/qualimap/downloads/qualimap_v2.2.1.zip && \
-    unzip qualimap_v2.2.1.zip && \
-    rm -rf qualimap_v2.2.1.zip && \
-    mv qualimap_v2.2.1 qualimap-bin
+    wget https://bitbucket.org/kokonech/qualimap/downloads/qualimap-build-10-10-16.tar.gz && \
+    tar -xzf qualimap-build-10-10-16.tar.gz && \
+    rm -rf qualimap-build-10-10-16.tar.gz && \
+    mv qualimap-build-10-10-16 qualimap-bin
 
 # copy in sdk module files
 COPY ./ /kb/module

--- a/Dockerfile
+++ b/Dockerfile
@@ -37,7 +37,7 @@ RUN chmod -R a+rw /kb/module
 # using 2.2.2-dev due to incorrect total reads count
 # https://groups.google.com/forum/#!topic/qualimap/boCICeLA_OM
 RUN cd /kb/module && \
-    wget https://bitbucket.org/kokonech/qualimap/downloads/qualimap-build-10-10-16.tar.gz && \
+    wget https://bitbucket.org/kokonech/qualimap/downloads/qualimap-build-26-08-18.tar.gz && \
     tar -xzf qualimap-build-10-10-16.tar.gz && \
     rm -rf qualimap-build-10-10-16.tar.gz && \
     mv qualimap-build-10-10-16 qualimap-bin


### PR DESCRIPTION
Qualimap released version seems to produce higher total reads count due to it’s taking account of secondary alignment. Switch to 2.2.2-dev seems to fix this issue. 

post from google group:
https://groups.google.com/forum/#!topic/qualimap/boCICeLA_OM